### PR TITLE
Use Swagger for brand and category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
-/storage/debugbar/
-/storage/api-docs/
 composer.lock
+/storage/debugbar/
+# Swagger documentation
+/storage/api-docs/
+/storage/api-docs/api-docs.json

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ It includes features like product management, category grouping, attributes, ima
 - ✅ RESTful API built with Laravel 12
 - ✅ API validation with Form Requests
 - ✅ Modular structure for future expansions
+<<<<<<< HEAD
 - ✅ **Email confirmation via Event + Listener + Queue**
+=======
+- ✅ **Swagger API documentation**
+>>>>>>> 770a6ec (Use Swagger for brand and category)
 
 ## 📦 Requirements
 
@@ -61,5 +65,6 @@ php artisan migrate --seed
 php artisan serve
 php artisan queue:work  # For production
 # php artisan queue:listen  # For development (restarts after each job)
+php artisan l5-swagger:generate
 ```
 ## License

--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -18,6 +18,29 @@ class BrandController extends Controller
         $this->brandService = $brandService;
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/admin/brands",
+     *     summary="Brands list",
+     *     tags={"Brands"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Get and show a list of brands on the Manage Brands page",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/Brand")
+     *         ),
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *      )
+     * )
+     */
     public function index()
     {
         $brands = $this->brandService->all();
@@ -25,6 +48,63 @@ class BrandController extends Controller
         return BrandResource::collection($brands);
     }
 
+    /**
+     * Store a newly created brand
+     *
+     * @OA\Post(
+     *     path="/api/admin/brands",
+     *     tags={"Brands"},
+     *     summary="Create a new brand",
+     *     description="Stores a new brand in the database",
+     *     operationId="storeBrand",
+     *     security={{"bearerAuth": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="Brand data",
+     *         @OA\JsonContent(
+     *             required={"name", "slug"},
+     *             @OA\Property(property="name", type="string", example="ORIGINAL"),
+     *             @OA\Property(property="description", type="string", example="ORIGINAL company", nullable=true),
+     *             @OA\Property(property="logo", type="string", format="binary", description="Brand logo image", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Brand created successfully",
+     *         @OA\JsonContent(ref="#/components/schemas/BrandResource")
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+     *             @OA\Property(
+     *                 property="errors",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="name",
+     *                     type="array",
+     *                     @OA\Items(type="string", example="The name field is required.")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     * )
+     */
     public function store(StoreBrandRequest $request)
     {
         $brand = $this->brandService->store($request);//parameter???
@@ -33,11 +113,95 @@ class BrandController extends Controller
 
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/admin/brands/{id}",
+     *     tags={"Brands"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="show a brand",
+     *    @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID of the brand",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(ref="#/components/schemas/BrandResource")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     *  )
+     */
     public function show(Brand $brand)
     {
         return new BrandResource($brand);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/admin/brands/{id}",
+     *     tags={"Brands"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="update a brand",
+     *    @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID of the brand to update",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(ref="#/components/schemas/BrandResource")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+     *             @OA\Property(
+     *                 property="errors",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="name",
+     *                     type="array",
+     *                     @OA\Items(type="string", example="The name field is required.")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     * )
+     */
     public function update(UpdateBrandRequest $request, Brand $brand)
     {
 
@@ -47,6 +211,43 @@ class BrandController extends Controller
 
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/admin/brands/{id}",
+     *     tags={"Brands"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="remove a brand",
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID of the brand to delete",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example="true"),
+     *            @OA\Property(property="message", type="string", example="Brand deleted successfully"),
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     *   )
+     */
     public function destroy(Brand $brand)
     {
         $this->brandService->destroy($brand);

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -7,50 +7,216 @@ use App\Http\Resources\Admin\CategoryResource;
 use App\Models\Category;
 use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
-use App\Services\CategoryService;
+use App\Services\Categorieservice;
 
 class CategoryController extends Controller
 {
-    protected $categoryService;
+    protected $categorieservice;
 
-    public function __construct(CategoryService $categoryService)
+    public function __construct(Categorieservice $categorieservice)
     {
-        $this->categoryService = $categoryService;
+        $this->categorieservice = $categorieservice;
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/admin/categories",
+     *     tags={"Categories"},
+     *     summary="categories list",
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="get and show list of categories in manage categories page",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/Category")
+     *         )
+     *     )
+     * )
+     */
     public function index()
     {
-        $categories = $this->categoryService->paginate();
+        $categories = $this->categorieservice->paginate();
 
         return CategoryResource::collection($categories);
 
     }
 
+    /**
+     * Store a newly created Category
+     *
+     * @OA\Post(
+     *     path="/api/admin/categories",
+     *     tags={"Categories"},
+     *     summary="Create a new Category",
+     *     description="Stores a new Category in the database",
+     *     operationId="storeCategory",
+     *     security={{"bearerAuth": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="Category data",
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="Arts Crafts Sewing"),
+     *             @OA\Property(property="description", type="string", example="Arts, Crafts & Sewing›Sewing›Sewing Project Kits", nullable=true),
+     *             @OA\Property(property="parent_id", type="integer", example="", nullable=true),
+     *             @OA\Property(property="icon", type="string", format="binary", description="Category icon image", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Category created successfully",
+     *         @OA\JsonContent(ref="#/components/schemas/CategoryResource")
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+     *             @OA\Property(
+     *                 property="errors",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="name",
+     *                     type="array",
+     *                     @OA\Items(type="string", example="The name field is required.")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     * )
+     */
     public function store(StoreCategoryRequest $request)
     {
 
-        $category = $this->categoryService->store($request->validated(), $request->hasFile('icon'), $request->file('icon'));
+        $category = $this->categorieservice->store($request->validated(), $request->hasFile('icon'), $request->file('icon'));
 
         return new CategoryResource($category);
 
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/admin/categories/{id}",
+     *     tags={"Categories"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="show a category",
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(ref="#/components/schemas/CategoryResource")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     * )
+     */
     public function show(Category $category)
     {
         return new CategoryResource($category);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/admin/categories/{id}",
+     *     tags={"Categories"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="update a category",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="Category data",
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="Arts Crafts Sewing"),
+     *             @OA\Property(property="description", type="string", example="Arts, Crafts & Sewing›Sewing›Sewing Project Kits", nullable=true),
+     *             @OA\Property(property="parent_id", type="integer", example="", nullable=true),
+     *             @OA\Property(property="icon", type="string", format="binary", description="Category icon image", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(ref="#/components/schemas/CategoryResource")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     * )
+     */
     public function update(UpdateCategoryRequest $request, Category $category)
     {
-        $category = $this->categoryService->update($category, $request->validated(), $request->hasFile('icon'), $request->file('icon'));
+        $category = $this->categorieservice->update($category, $request->validated(), $request->hasFile('icon'), $request->file('icon'));
 
         return new CategoryResource($category);
 
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/admin/categories/{id}",
+     *     tags={"Categories"},
+     *     security={{"bearerAuth": {}}},
+     *     summary="remove a category",
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful request response",
+     *         @OA\JsonContent(ref="#/components/schemas/CategoryResource")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Internal server error occurred.")
+     *         )
+     *     )
+     *   ),
+     */
     public function destroy(Category $category)
     {
-        $this->categoryService->destroy($category);
+        $this->categorieservice->destroy($category);
 
         return response()->json(
             [

--- a/app/Http/Controllers/SwaggerController.php
+++ b/app/Http/Controllers/SwaggerController.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace App\Http\Controllers;
+
+/**
+ * @OA\Info(
+ *     title="Shop API",
+ *     version="1.0.0",
+ *     description="Shop documentations"
+ * )
+ */
+class SwaggerController extends Controller
+{
+    //
+}

--- a/app/Http/Resources/Admin/BrandResource.php
+++ b/app/Http/Resources/Admin/BrandResource.php
@@ -8,9 +8,20 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class BrandResource extends JsonResource
 {
     /**
-     * Transform the resource into an array.
-     *
-     * @return array<string, mixed>
+     * @OA\Schema(
+     *     schema="BrandResource",
+     *     type="object",
+     *     title="Brand Resource",
+     *     @OA\Property(property="id", type="integer", example=1),
+     *     @OA\Property(property="name", type="string", example="ORIGINAL"),
+     *     @OA\Property(property="slug", type="string", example="original"),
+     *     @OA\Property(property="description", type="string", example="ORIGINAL company", nullable=true),
+     *     @OA\Property(property="logo", type="string", example="brands/original.png", nullable=true),
+     *     @OA\Property(property="is_active", type="boolean", example=true),
+     *     @OA\Property(property="created_at", type="string", format="date-time", example="2023-01-01T12:00:00Z"),
+     *     @OA\Property(property="updated_at", type="string", format="date-time", example="2023-01-01T12:00:00Z"),
+     *     @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null),
+     * )
      */
     public function toArray(Request $request): array
     {

--- a/app/Http/Resources/Admin/CategoryResource.php
+++ b/app/Http/Resources/Admin/CategoryResource.php
@@ -8,9 +8,20 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class CategoryResource extends JsonResource
 {
     /**
-     * Transform the resource into an array.
-     *
-     * @return array<string, mixed>
+     * @OA\Schema(
+     *     schema="CategoryResource",
+     *     type="object",
+     *     title="Category Resource",
+     *     @OA\Property(property="id", type="integer", example=1),
+     *     @OA\Property(property="name", type="string", example="ORIGINAL"),
+     *     @OA\Property(property="slug", type="string", example="original"),
+     *     @OA\Property(property="description", type="string", example="ORIGINAL company", nullable=true),
+     *     @OA\Property(property="logo", type="string", example="Category/original.png", nullable=true),
+     *     @OA\Property(property="is_active", type="boolean", example=true),
+     *     @OA\Property(property="created_at", type="string", format="date-time", example="2023-01-01T12:00:00Z"),
+     *     @OA\Property(property="updated_at", type="string", format="date-time", example="2023-01-01T12:00:00Z"),
+     *     @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null),
+     * )
      */
     public function toArray(Request $request): array
     {

--- a/app/Swagger/Schemas/BrandSchema.php
+++ b/app/Swagger/Schemas/BrandSchema.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace App\Swagger\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Brand",
+ *     type="object",
+ *     title="Brand",
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="ORIGINAL"),
+ *     @OA\Property(property="slug", type="string", example="original"),
+ *     @OA\Property(property="description", type="string", example="ORIGINAL Desc"),
+ *     @OA\Property(property="logo", type="string", example="brands/original.png"),
+ *     @OA\Property(property="is_active", type="integer", example=1),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-05-17T10:19:07.000000Z"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-05-17T10:19:07.000000Z"),
+ *     @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null),
+ * )
+ */
+class BrandSchema
+{
+}

--- a/app/Swagger/Schemas/CategorySchema.php
+++ b/app/Swagger/Schemas/CategorySchema.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace App\Swagger\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Category",
+ *     type="object",
+ *     title="Category",
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="ORIGINAL"),
+ *     @OA\Property(property="slug", type="string", example="original"),
+ *     @OA\Property(property="description", type="string", example="ORIGINAL Desc"),
+ *     @OA\Property(property="logo", type="string", example="categories/original.png"),
+ *     @OA\Property(property="is_active", type="integer", example=1),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-05-17T10:19:07.000000Z"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-05-17T10:19:07.000000Z"),
+ *     @OA\Property(property="deleted_at", type="string", format="date-time", nullable=true, example=null),
+ * )
+ */
+class CategorySchema
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
+        "darkaonline/l5-swagger": "^9.0",
+        "zircote/swagger-php": "^5.1",
         "ext-curl": "*"
     },
     "require-dev": {

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,318 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive Swagger (OpenAPI) documentation for brand and category management APIs, including detailed endpoint annotations and response schemas.
  - Introduced Swagger API documentation generation and access via new configuration and controller.
  - Updated README with new feature and installation steps for generating API docs.

- **Chores**
  - Added and configured dependencies for Swagger API documentation.
  - Updated `.gitignore` to exclude Swagger-generated files and other artifacts.

- **Documentation**
  - Enhanced resource and schema annotations for brands and categories to improve API documentation clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->